### PR TITLE
misc changes to print_oops.c

### DIFF
--- a/kernel/print_oops.c
+++ b/kernel/print_oops.c
@@ -35,6 +35,8 @@ static int buf_pos;
 static DEFINE_MUTEX(compr_mutex);
 static struct z_stream_s stream;
 
+static int bug_in_code;
+
 void qr_append(char *text)
 {
 	size_t len;
@@ -140,6 +142,13 @@ void print_qr_err(void)
 	if (!qr_oops)
 		return;
 
+	if (bug_in_code) {
+		printk(KERN_EMERG "QR encoding triggers an error. Disabling.\n");
+		return;
+	}
+
+	bug_in_code ++;
+
 	info = registered_fb[0];
 	if (!info) {
 		printk(KERN_WARNING "Unable to get hand of a framebuffer!\n");
@@ -202,5 +211,6 @@ void print_qr_err(void)
 	QRcode_free(qr);
 	qr_compr_exit();
 	buf_pos = 0;
+	bug_in_code --;
 }
 


### PR DESCRIPTION
The following changes since commit 8ed5d21435b095896d3d6a9ce00b728f647009f1:

  Merge pull request #4 from levex/for-teodora (2014-04-13 22:55:57 +0300)

are available in the git repository at:

  https://github.com/levex/qr-linux-kernel for-teodora

for you to fetch changes up to 4ab5c9484a542b5da351757b094e2258f97f393a:

  qr: print_oops: implement guarding against recursive error in QR lib (2014-05-06 12:41:07 +0200)

---

Hi Teodora,

please consider pulling.

I will send you another pull request containing some considerable changes to lib/qr/bitstream.c

From now on, I'll work on removing unneeded modes and MicroQR (MQR) from the lib.

Thanks, Lev.

---

Levente Kurusa (5):
      qr: print_oops: remove redundant err variable
      qr: print_oops: remove __init from qr_compr_init
      qr: print_oops: show error message when encoding failed
      qr: print_oops: show a message when compression of QR code failed
      qr: print_oops: implement guarding against recursive error in QR lib

 kernel/print_oops.c | 41 ++++++++++++++++++++++++++++-------------
 1 file changed, 28 insertions(+), 13 deletions(-)
