### PR TITLE
qr: bitstream: rewrite to use 8 times less memory

### DIFF
--- a/lib/qr/bitstream.h
+++ b/lib/qr/bitstream.h
@@ -1,8 +1,7 @@
 /*
- * qrencode - QR Code encoder
+ * BitStream - storage of bits to which you can append
  *
- * Binary sequence class.
- * Copyright (C) 2006-2011 Kentaro Fukuchi <kentaro@fukuchi.org>
+ * Copyright (C) 2014 Levente Kurusa <levex@linux.com>
  *
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,23 +14,30 @@
  * GNU General Public License for more details.
  *
  */
+#ifndef __BITSTREAM_H
+#define __BITSTREAM_H
 
-#ifndef __BITSTREAM_H__
-#define __BITSTREAM_H__
+#include <linux/kernel.h>
+#include <linux/gfp.h>
+#include <linux/spinlock.h>
 
 struct BitStream {
+	u8 *_data;
 	int length;
-	unsigned char *data;
+	int space;
+	spinlock_t lock;
+	gfp_t gfp;
 };
 
+extern struct BitStream *BitStream_allocate(int length, gfp_t gfp);
 extern struct BitStream *BitStream_new(void);
-extern int BitStream_append(struct BitStream *bstream, struct BitStream *arg);
-extern int BitStream_appendNum(struct BitStream *bstream, int bits,
-			       unsigned int num);
-extern int BitStream_appendBytes(struct BitStream *bstream, int size,
-				 unsigned char *data);
-#define BitStream_size(__bstream__) (__bstream__->length)
-extern unsigned char *BitStream_toByte(struct BitStream *bstream);
-extern void BitStream_free(struct BitStream *bstream);
+extern void BitStream_free(struct BitStream *bstr);
+extern int BitStream_appendBytes(struct BitStream *bstr, int len, u8 *data);
+extern int BitStream_appendNum(struct BitStream *bstr, int bits, int num);
+extern int BitStream_append(struct BitStream *dst, struct BitStream *src);
+extern unsigned char *BitStream_toByte(struct BitStream *bstr);
 
-#endif /* __BITSTREAM_H__ */
+#define BitStream_size(b) (b->length)
+
+
+#endif /* __BITSTREAM_H */


### PR DESCRIPTION
Hi Teodora,

The following changes since commit 8ed5d21435b095896d3d6a9ce00b728f647009f1:

  Merge pull request #4 from levex/for-teodora (2014-04-13 22:55:57 +0300)

are available in the git repository at:

  https://github.com/levex/qr-linux-kernel for-teodora-bitstream

for you to fetch changes up to 821370f7aded488ee7e00527044db9fbd031f32e:

  qr: bitstream: rewrite to use 8 times less memory (2014-05-07 11:42:03 +0200)

---

Pretty much what the commit says. I guess it could do
with some review, but it worked for me.

Please consider pulling.

Thanks, Lev.

---

Levente Kurusa (1):
      qr: bitstream: rewrite to use 8 times less memory

 lib/qr/bitstream.c | 277 ++++++++++++++++++++++++-----------------------------
 lib/qr/bitstream.h |  36 ++++---
 2 files changed, 147 insertions(+), 166 deletions(-)
