### PR TITLE
Config related clean ups

### DIFF
--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -17,7 +17,8 @@ config PRINTK_TIME
 
 config QR_OOPS
 	bool "Display QR barcode for Oops messages for debug"
-	depends on PRINTK && QRLIB
+	depends on PRINTK
+	select QRLIB
 	help
 		Selecting this option makes printk() calls to accumulate
 		the Oops messages in a buffer, compresses the message

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -16,7 +16,7 @@ config PRINTK_TIME
 	  parameter printk.time=1. See Documentation/kernel-parameters.txt
 
 config QR_OOPS
-	bool "Display QR barcode for Oops messages for debug"
+	bool "Display QR barcode for Oops messages for debugging purposes"
 	depends on PRINTK
 	select QRLIB
 	help

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -17,8 +17,11 @@ config PRINTK_TIME
 
 config QR_OOPS
 	bool "Display QR barcode for Oops messages for debugging purposes"
-	depends on PRINTK
+	depends on PRINTK && FB
 	select QRLIB
+	select ZLIB_DEFLATE
+	select ZLIB_INFLATE
+	select FB_CFB_FILLRECT
 	help
 		Selecting this option makes printk() calls to accumulate
 		the Oops messages in a buffer, compresses the message


### PR DESCRIPTION
Hi Teodora,

The following changes since commit c1e0719b117ec27fe9b0c6df1a58f5bb91bc4394:

  qr: remove kanji support from qr library (2014-12-30 14:39:44 +0200)

are available in the git repository at:

  https://github.com/levex/qr-linux-kernel for-teodora-kconfig

for you to fetch changes up to c78683e746071fc245fbcc2763d8b15a91034412:

  qr: config: fix dependencies for QR_OOPS (2015-01-02 11:21:37 +0100)

----------------------------------------------------------------

Just a few configuration related commits.
Will send a few more pull requests later today or tomorrow.

Thanks!

----------------------------------------------------------------
Levente Kurusa (3):
      qr: QR encoded oops should be selectable without QR lib
      qr: Kconfig: fix English in the option name
      qr: config: fix dependencies for QR_OOPS

 lib/Kconfig.debug | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
