### PR TITLE
Random changes for the QR library

### DIFF
--- a/lib/qr/bitstream.c
+++ b/lib/qr/bitstream.c
@@ -72,7 +72,7 @@ int BitStream_resize(struct BitStream *bstr, int nspace)
 {
 	unsigned char *data;
 
-	if (!bstr || nspace == 0)
+	if (nspace == 0)
 		return -EINVAL;
 
 	if (bstr->length >= nspace)
@@ -94,11 +94,8 @@ int BitStream_resize(struct BitStream *bstr, int nspace)
 
 int __BitStream_get_bit(struct BitStream *bstr, int no)
 {
-	if (!bstr || !bstr->data)
-		return -EINVAL;
-
-	if (no > bstr->length)
-		return -EINVAL;
+	if (WARN_ON(no > bstr->length))
+		return 0;
 
 	return (bstr->data[no / 8] & (1 << (no % 8))) ? 1 : 0;
 }
@@ -106,9 +103,6 @@ int __BitStream_get_bit(struct BitStream *bstr, int no)
 int __BitStream_append_bit(struct BitStream *bstr, u8 bit)
 {
 	int rc;
-
-	if (!bstr)
-		return -EINVAL;
 
 	if (!bstr->data || bstr->length + 1 >= bstr->space) {
 		rc = BitStream_resize(bstr, bstr->space + 256);

--- a/lib/qr/bitstream.c
+++ b/lib/qr/bitstream.c
@@ -19,7 +19,7 @@
 #include <linux/slab.h>
 #include "bitstream.h"
 
-#define BITS_TO_BYTES(x) (((x) % 8 ) ? ((x) / 8 + 1) : ((x) / 8))
+#define BITS_TO_BYTES(x) (((x) % 8) ? ((x) / 8 + 1) : ((x) / 8))
 
 u8 *__BitStream_alloc_data(int len, gfp_t gfp)
 {
@@ -37,7 +37,7 @@ struct BitStream *BitStream_allocate(int space, gfp_t gfp)
 	bstr = kzalloc(sizeof(*bstr), gfp);
 	if (!bstr)
 		return NULL;
-	
+
 	bstr->gfp = gfp;
 
 	if (space == 0)
@@ -64,8 +64,7 @@ void BitStream_free(struct BitStream *bstr)
 {
 	if (!bstr)
 		return;
-	if (bstr->data)
-		kfree(bstr->data);
+	kfree(bstr->data);
 	kfree(bstr);
 }
 
@@ -75,14 +74,14 @@ int BitStream_resize(struct BitStream *bstr, int nspace)
 
 	if (!bstr || nspace == 0)
 		return -EINVAL;
-	
+
 	if (bstr->length >= nspace)
 		return -ENOSPC;
-	
+
 	data = kzalloc(BITS_TO_BYTES(nspace), bstr->gfp);
 	if (!data)
 		return -ENOMEM;
-	
+
 	if (bstr->data) {
 		memcpy(data, bstr->data, BITS_TO_BYTES(bstr->length));
 		kfree(bstr->data);
@@ -97,7 +96,7 @@ int __BitStream_get_bit(struct BitStream *bstr, int no)
 {
 	if (!bstr || !bstr->data)
 		return -EINVAL;
-	
+
 	if (no > bstr->length)
 		return -EINVAL;
 
@@ -107,7 +106,7 @@ int __BitStream_get_bit(struct BitStream *bstr, int no)
 int __BitStream_append_bit(struct BitStream *bstr, u8 bit)
 {
 	int rc;
-	
+
 	if (!bstr)
 		return -EINVAL;
 
@@ -116,13 +115,13 @@ int __BitStream_append_bit(struct BitStream *bstr, u8 bit)
 		if (rc)
 			return rc;
 	}
-	
+
 	if (bit != 0)
 		bstr->data[bstr->length / 8] |= (1UL << (bstr->length % 8));
-	else {
+	else
 		bstr->data[bstr->length / 8] &= ~(1UL << (bstr->length % 8));
-	}
-	bstr->length ++;
+
+	bstr->length++;
 
 	return 0;
 }
@@ -136,7 +135,7 @@ int BitStream_appendBytes(struct BitStream *bstr, int bytes, u8 *data)
 	for (i = 0; i < bytes; i++) {
 		mask = 0x80;
 		for (j = 0; j < 8; j++) {
-			rc =__BitStream_append_bit(bstr, data[i] & mask);
+			rc = __BitStream_append_bit(bstr, data[i] & mask);
 			if (rc)
 				return rc;
 			mask = mask >> 1;
@@ -151,7 +150,7 @@ int BitStream_appendNum(struct BitStream *bstr, int bits, int num)
 	int rc;
 	int i;
 	unsigned int mask;
-	
+
 	mask = 1 << (bits - 1);
 	for (i = 0; i < bits; i++) {
 		rc = __BitStream_append_bit(bstr, num & mask);
@@ -159,7 +158,7 @@ int BitStream_appendNum(struct BitStream *bstr, int bits, int num)
 			return rc;
 		mask = mask >> 1;
 	}
-	
+
 	return 0;
 }
 
@@ -172,7 +171,7 @@ int BitStream_append(struct BitStream *dst, struct BitStream *src)
 		if (rc)
 			return rc;
 	}
-	
+
 	return 0;
 }
 
@@ -180,7 +179,7 @@ unsigned char *BitStream_toByte(struct BitStream *bstr)
 {
 	unsigned char *data, v;
 	int i, j, size, bytes, p;
-	
+
 	data = kzalloc((bstr->length + 7) / 8, bstr->gfp);
 	if (!data)
 		return NULL;
@@ -192,7 +191,7 @@ unsigned char *BitStream_toByte(struct BitStream *bstr)
 		for (j = 0; j < 8; j++) {
 			v = v << 1;
 			v |= __BitStream_get_bit(bstr, p);
-			p ++;
+			p++;
 		}
 		data[i] = v;
 	}
@@ -201,10 +200,10 @@ unsigned char *BitStream_toByte(struct BitStream *bstr)
 		for (j = 0; j < (size & 7); j++) {
 			v = v << 1;
 			v |= __BitStream_get_bit(bstr, p);
-			p ++;
+			p++;
 		}
 		data[bytes] = v;
 	}
-	
+
 	return data;
 }

--- a/lib/qr/mask.c
+++ b/lib/qr/mask.c
@@ -142,21 +142,6 @@ static MaskMaker *maskMakers[maskNum] = {
 	Mask_mask4, Mask_mask5, Mask_mask6, Mask_mask7
 };
 
-#ifdef WITH_TESTS
-unsigned char *Mask_makeMaskedFrame(int width, unsigned char *frame, int mask)
-{
-	unsigned char *masked;
-
-	masked = kmalloc(width * width, GFP_ATOMIC);
-	if (masked == NULL)
-		return NULL;
-
-	maskMakers[mask] (width, frame, masked);
-
-	return masked;
-}
-#endif
-
 unsigned char *Mask_makeMask(int width, unsigned char *frame, int mask,
 			     enum QRecLevel level)
 {

--- a/lib/qr/mask.h
+++ b/lib/qr/mask.h
@@ -24,16 +24,4 @@ extern unsigned char *Mask_makeMask(int width, unsigned char *frame,
 extern unsigned char *Mask_mask(int width, unsigned char *frame,
 				enum QRecLevel level);
 
-#ifdef WITH_TESTS
-extern int Mask_calcN2(int width, unsigned char *frame);
-extern int Mask_calcN1N3(int length, int *runLength);
-extern int Mask_calcRunLength(int width, unsigned char *frame,
-			      int dir, int *runLength);
-extern int Mask_evaluateSymbol(int width, unsigned char *frame);
-extern int Mask_writeFormatInformation(int width, unsigned char *frame,
-				       int mask, enum QRecLevel level);
-extern unsigned char *Mask_makeMaskedFrame(int width, unsigned char *frame,
-					   int mask);
-#endif
-
 #endif /* __MASK_H__ */

--- a/lib/qr/mmask.h
+++ b/lib/qr/mmask.h
@@ -24,13 +24,4 @@ extern unsigned char *MMask_makeMask(int version, unsigned char *frame,
 extern unsigned char *MMask_mask(int version, unsigned char *frame,
 				 enum QRecLevel level);
 
-#ifdef WITH_TESTS
-extern int MMask_evaluateSymbol(int width, unsigned char *frame);
-extern void MMask_writeFormatInformation(int version, int width,
-					 unsigned char *frame, int mask,
-					 enum QRecLevel level);
-extern unsigned char *MMask_makeMaskedFrame(int width, unsigned char *frame,
-					    int mask);
-#endif
-
 #endif /* __MMASK_H__ */

--- a/lib/qr/qrinput.c
+++ b/lib/qr/qrinput.c
@@ -383,8 +383,8 @@ static int QRinput_encodeModeNum(struct QRinput_List *entry, int version)
 		goto ABORT;
 
 	ret = BitStream_appendNum(entry->bstream,
-	   			  QRspec_lengthIndicator(QR_MODE_NUM,
-				  version), entry->size);
+				  QRspec_lengthIndicator(QR_MODE_NUM, version),
+				  entry->size);
 	if (ret < 0)
 		goto ABORT;
 
@@ -1148,7 +1148,7 @@ static struct BitStream *QRinput_mergeBitStream(struct QRinput *input)
 
 	if (input->fnc1) {
 		if (QRinput_insertFNC1Header(input) < 0)
-		return NULL;
+			return NULL;
 	}
 	if (QRinput_convertData(input) < 0)
 		return NULL;

--- a/lib/qr/qrinput.h
+++ b/lib/qr/qrinput.h
@@ -114,15 +114,4 @@ extern const signed char QRinput_anTable[128];
  */
 #define MAX_STRUCTURED_SYMBOLS 16
 
-#ifdef WITH_TESTS
-extern struct BitStream *QRinput_mergeBitStream(struct QRinput *input);
-extern struct BitStream *QRinput_getBitStream(struct QRinput *input);
-extern int QRinput_estimateBitStreamSize(struct QRinput *input, int version);
-extern int QRinput_splitEntry(struct QRinput_List *entry, int bytes);
-extern int QRinput_lengthOfCode(enum QRencodeMode mode, int version, int bits);
-extern int QRinput_insertStructuredAppendHeader(struct QRinput *input,
-						int size, int index,
-						unsigned char parity);
-#endif
-
 #endif /* __QRINPUT_H__ */

--- a/lib/qr/split.c
+++ b/lib/qr/split.c
@@ -34,15 +34,6 @@
 #define isdigit(__c__) ((unsigned char)((signed char)(__c__) - '0') < 10)
 #define isalnum(__c__) (QRinput_lookAnTable(__c__) >= 0)
 
-char *strdup(const char *s)
-{
-	size_t len = strlen(s) + 1;
-	void *new = kmalloc(len, GFP_ATOMIC);
-	if (new == NULL)
-		return NULL;
-	return (char *)memcpy(new, s, len);
-}
-
 static enum QRencodeMode Split_identifyMode(const char *string,
 					    enum QRencodeMode hint)
 {
@@ -253,7 +244,7 @@ static char *dupAndToUpper(const char *str, enum QRencodeMode hint)
 	char *newstr, *p;
 	enum QRencodeMode mode;
 
-	newstr = strdup(str);
+	newstr = kstrdup(str, GFP_ATOMIC);
 	if (newstr == NULL)
 		return NULL;
 


### PR DESCRIPTION
Hi Teodora,

The following changes since commit c1e0719b117ec27fe9b0c6df1a58f5bb91bc4394:

  qr: remove kanji support from qr library (2014-12-30 14:39:44 +0200)

are available in the git repository at:

  https://github.com/levex/qr-linux-kernel for-teodora-misc

for you to fetch changes up to cb204c1a5bfe92cafc17aee55ce1b8590aaa6db2:

  qr: split: use kstrdup (2015-01-02 18:14:51 +0100)

----------------------------------------------------------------

Mainly cleanups.

Please pull.

Thanks,
Lev

----------------------------------------------------------------
Levente Kurusa (5):
      qr: bitstream: fix coding style
      qr: qrinput: fix indentation style
      bitstream: remove useless checks
      qr: remove WITH_TESTS parts
      qr: split: use kstrdup

 lib/qr/bitstream.c | 49 +++++++++++++++++++++----------------------------
 lib/qr/mask.c      | 15 ---------------
 lib/qr/mask.h      | 12 ------------
 lib/qr/mmask.h     |  9 ---------
 lib/qr/qrinput.c   |  4 ++--
 lib/qr/qrinput.h   | 11 -----------
 lib/qr/split.c     | 11 +----------
 7 files changed, 24 insertions(+), 87 deletions(-)
