### PR TITLE
print_oops related changes

### DIFF
--- a/kernel/print_oops.c
+++ b/kernel/print_oops.c
@@ -67,7 +67,8 @@ static inline int compute_w(struct fb_info *info, int qrw)
 			ret /= qr_oops;
 			qr_oops--;
 			ret *= qr_oops;
-			if (ret <= xres && ret <= yres)
+			/* Leave some spaces around the edges FIXME: correct? */
+			if (ret <= (minxy - qr_oops))
 				goto exit;
 		}
 		printk(KERN_WARNING "Was unable to find suitable scaling!\n");


### PR DESCRIPTION
Hey Teodora,

The following changes since commit c1e0719b117ec27fe9b0c6df1a58f5bb91bc4394:

  qr: remove kanji support from qr library (2014-12-30 14:39:44 +0200)

are available in the git repository at:

  https://github.com/levex/qr-linux-kernel for-teodora-print_oops

for you to fetch changes up to e282d8603217d119982b88568fb1a63b43663389:

  qr: print_oops: leave some space around the edges of the screen (2015-01-02 22:12:54 +0100)

----------------------------------------------------------------

Now these ones are interesting.

First, we need to clear the remaining parts of the previous QR code, since
otherwise sometimes specific QR scanners would fail to properly detect the
QR code... This happens when the second Oops that comes immediately
after the first one is smaller than the first one. In this case we will have
two top-right locator schemes in the QR code on screen, which confuses
scanners. Fix this.

Second commit is a bug fix. While testing the RS merging, I switched to
a string 'hello, world', so that I could use some consistency checking...
Anyway, with that string being encoded the resulting QR code is exactly
the size of the available resolution and hence results in an Oops. This is
a fault of logic on my part. Originally the code wouldn't account for the last
column and row of the QR code and hence those could be out of range.
Fix this.

Please consider pulling,
Thanks,
Lev.

----------------------------------------------------------------
Levente Kurusa (2):
      qr: print_oops: clear traces of previous QR code
      qr: print_oops: leave some space around the edges of the screen

 kernel/print_oops.c | 23 ++++++++++++++++++++++-
 1 file changed, 22 insertions(+), 1 deletion(-)
